### PR TITLE
Fix idiom for iOS marketing image

### DIFF
--- a/src/components/tools/tools.ts
+++ b/src/components/tools/tools.ts
@@ -142,7 +142,7 @@ export class ToolsComponent extends Vue {
                             new FileSpec('-60x60@3x.png', 60, 60, null, 'iphone', 3),
                             new FileSpec('-76x76@1x.png', 76, 76, null, 'ipad', 1),
                             new FileSpec('-76x76@2x.png', 76, 76, null, 'ipad', 2),
-                            new FileSpec('-marketing-1024x1024.png', 1024, 1024, null, 'iphone', 1),
+                            new FileSpec('-marketing-1024x1024.png', 1024, 1024, null, 'ios-marketing', 1),
                         ]
                     },
                     {


### PR DESCRIPTION
Thanks for Ape Tools!

I believe that the `idiom` for the iOS marketing image is currently incorrect. See https://developer.apple.com/library/content/documentation/Xcode/Reference/xcode_ref-Asset_Catalog_Format/ImageSetType.html#//apple_ref/doc/uid/TP40015170-CH25-SW2.

Of course, I could be wrong :)